### PR TITLE
Hide ExampleIosApp from SPM dependency navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-02-16
+
+### Fixed
+
+- Examples folder no longer appears in Xcode's dependency navigator for SPM consumers. Added a minimal `Package.swift` to `Examples/ExampleIosApp/` so SPM treats it as a separate package.
+
 ## [1.1.0] - 2026-02-16
 
 ### Added
@@ -45,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SingletonScope` and `AlwaysCreateNewScope` built-in scopes.
 - Swift Package Manager support.
 
+[1.1.1]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.8...1.1.0
 [1.0.8]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.0...1.0.8
 [1.0.0]: https://github.com/robert-northmind/SwiftiePod/releases/tag/1.0.0

--- a/Examples/ExampleIosApp/Package.swift
+++ b/Examples/ExampleIosApp/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 5.8
+// This Package.swift exists so that SPM treats this directory as a separate
+// package and excludes it from the parent SwiftiePod package's file listing.
+// The actual build is done via the .xcodeproj.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExampleIosApp"
+)

--- a/SwiftiePod.podspec
+++ b/SwiftiePod.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'SwiftiePod'
-    s.version      = '1.1.0'
+    s.version      = '1.1.1'
     s.summary      = 'A Dependency Injection library for Swift'
     s.description  = 'SwiftiePod is a lightweight and easy-to-use Dependency Injection (DI) library for Swift. It is designed to be straightforward, efficient, and most importantly safe!'
     s.homepage     = 'https://github.com/robert-northmind/SwiftiePod'


### PR DESCRIPTION
## Summary
- Add a minimal `Package.swift` to `Examples/ExampleIosApp/` so SPM treats it as a separate package and excludes it from consumers' Xcode file navigators
- Bump version to 1.1.1

## Context
When consumers add SwiftiePod via SPM, Xcode shows the `Examples/ExampleIosApp` folder in the dependency navigator. `Examples/ExampleApp` was already hidden because it has its own `Package.swift`. This fix applies the same approach to the iOS example.

## Test plan
- [ ] Add SwiftiePod 1.1.1 as an SPM dependency in another project and verify Examples no longer appears in the navigator
- [ ] `swift build` passes
- [ ] `swift test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)