### PR TITLE
Fix: properly hide ExampleIosApp from SPM navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-02-16
+
+### Fixed
+
+- Examples folder no longer appears in Xcode's dependency navigator for SPM consumers. The `Package.swift` in `Examples/ExampleIosApp/` now defines a proper target so SPM recognizes it as a separate nested package.
+
 ## [1.1.1] - 2026-02-16
 
 ### Fixed
 
-- Examples folder no longer appears in Xcode's dependency navigator for SPM consumers. Added a minimal `Package.swift` to `Examples/ExampleIosApp/` so SPM treats it as a separate package.
+- (Superseded by 1.1.2) Initial attempt to hide Examples from SPM navigator.
 
 ## [1.1.0] - 2026-02-16
 
@@ -51,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SingletonScope` and `AlwaysCreateNewScope` built-in scopes.
 - Swift Package Manager support.
 
+[1.1.2]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.8...1.1.0
 [1.0.8]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.0...1.0.8

--- a/Examples/ExampleIosApp/Package.swift
+++ b/Examples/ExampleIosApp/Package.swift
@@ -6,5 +6,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "ExampleIosApp"
+    name: "ExampleIosApp",
+    platforms: [.iOS(.v16)],
+    dependencies: [
+        .package(path: "../../")
+    ],
+    targets: [
+        .target(
+            name: "ExampleIosApp",
+            dependencies: [.product(name: "SwiftiePod", package: "SwiftiePod")],
+            path: "ExampleIosApp"
+        )
+    ]
 )

--- a/SwiftiePod.podspec
+++ b/SwiftiePod.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'SwiftiePod'
-    s.version      = '1.1.1'
+    s.version      = '1.1.2'
     s.summary      = 'A Dependency Injection library for Swift'
     s.description  = 'SwiftiePod is a lightweight and easy-to-use Dependency Injection (DI) library for Swift. It is designed to be straightforward, efficient, and most importantly safe!'
     s.homepage     = 'https://github.com/robert-northmind/SwiftiePod'


### PR DESCRIPTION
## Summary
- The minimal `Package.swift` (no targets) from 1.1.1 wasn't enough — SPM needs a proper target definition to recognize a nested package
- Updated `Examples/ExampleIosApp/Package.swift` with a real target and dependency, matching how `Examples/ExampleApp/Package.swift` is structured
- Bump version to 1.1.2

## Test plan
- [ ] Add SwiftiePod 1.1.2 as an SPM dependency and verify Examples no longer appears in Xcode navigator
- [ ] `swift build` passes
- [ ] `swift test` passes (33 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)