### PR TITLE
Detect re-entrant self-cycle via direct pod reference (issue #5) + v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-03-31
+
+### Fixed
+
+- Re-entrant `pod.resolve()` calls from within a provider builder no longer deadlock. When code reachable from a builder holds a direct reference to the `SwiftiePod` instance and calls `resolve()` on it (e.g. a `Log` shim resolving a logger from a global pod), the container now detects the re-entrant call and bypasses the internal lock instead of deadlocking.
+- Re-entrant self-cycles — where a provider's builder calls `pod.resolve()` on itself via a direct pod reference — are now detected and reported via `cyclicDependencyHandler` instead of causing infinite recursion and a stack overflow.
+
 ## [1.1.2] - 2026-02-16
 
 ### Fixed
@@ -57,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SingletonScope` and `AlwaysCreateNewScope` built-in scopes.
 - Swift Package Manager support.
 
+[1.1.3]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.2...1.1.3
 [1.1.2]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.8...1.1.0

--- a/Sources/SwiftiePod/InternalProviderResolver.swift
+++ b/Sources/SwiftiePod/InternalProviderResolver.swift
@@ -11,26 +11,32 @@ struct InternalProviderResolver: ProviderResolver {
     init(
         instanceContainer: ProviderInstanceContainer,
         processingAnyProviders: ProcessingAnyProviders,
-        providerOverrider: ProviderOverrider
+        providerOverrider: ProviderOverrider,
+        onBuildStart: ((ObjectIdentifier) -> Void)? = nil,
+        onBuildEnd: ((ObjectIdentifier) -> Void)? = nil
     ) {
         self.instanceContainer = instanceContainer
         self.processingAnyProviders = processingAnyProviders
         self.providerOverrider = providerOverrider
+        self.onBuildStart = onBuildStart
+        self.onBuildEnd = onBuildEnd
     }
 
     private let instanceContainer: ProviderInstanceContainer
     private let processingAnyProviders: ProcessingAnyProviders
     private let providerOverrider: ProviderOverrider
+    private let onBuildStart: ((ObjectIdentifier) -> Void)?
+    private let onBuildEnd: ((ObjectIdentifier) -> Void)?
 
     func resolve<T>(_ originalProvider: Provider<T>) -> T {
         let anyProvider = AnyProvider(originalProvider)
-        
+
         let overriddenProvider = providerOverrider.getOverriddenAnyProvider(originalProvider)?.base as? Provider<T>
         let provider = overriddenProvider ?? originalProvider
         let wasOverridden = providerOverrider.isProviderOverridden(originalProvider)
 
         let isAllowedToCacheInstance = !(provider.scope is AlwaysCreateNewScope)
-        
+
         if isAllowedToCacheInstance {
             if wasOverridden {
                 if let overriddenInstance = providerOverrider.getOverriddenProviderInstance(originalProvider) as? T {
@@ -43,6 +49,8 @@ struct InternalProviderResolver: ProviderResolver {
 
         checkCyclicDependency(anyProvider: anyProvider, processingAnyProviders: processingAnyProviders)
 
+        let buildID = ObjectIdentifier(originalProvider)
+        onBuildStart?(buildID)
         let newInstance = provider.build(
             InternalProviderResolver(
                 instanceContainer: instanceContainer,
@@ -50,9 +58,12 @@ struct InternalProviderResolver: ProviderResolver {
                     processingAnyProviders,
                     withAnyProvider: anyProvider
                 ),
-                providerOverrider: providerOverrider
+                providerOverrider: providerOverrider,
+                onBuildStart: onBuildStart,
+                onBuildEnd: onBuildEnd
             )
         )
+        onBuildEnd?(buildID)
 
         if isAllowedToCacheInstance {
             if wasOverridden {

--- a/Sources/SwiftiePod/SwiftiePod.swift
+++ b/Sources/SwiftiePod/SwiftiePod.swift
@@ -33,6 +33,10 @@ public final class SwiftiePod: ProviderResolver, @unchecked Sendable {
 
     private let instanceContainer = ProviderInstanceContainer()
     private let providerOverrider: ProviderOverrider
+    // Tracks providers whose builder is actively on the call stack, so that
+    // re-entrant calls to pod.resolve() on the same provider can be detected
+    // as self-referential cycles rather than silently recursing forever.
+    private var currentlyBuildingProviders = Set<ObjectIdentifier>()
 
     /// Resolves a provider to its associated instance.
     ///
@@ -54,6 +58,12 @@ public final class SwiftiePod: ProviderResolver, @unchecked Sendable {
         // If we are already executing on the queue (re-entrant call from within a builder
         // that references this pod directly), skip the `sync` to prevent a deadlock.
         if DispatchQueue.getSpecific(key: queueKey) == true {
+            // Detect a self-referential cycle: the same provider's builder is already
+            // on the call stack and has called pod.resolve() on itself.
+            if currentlyBuildingProviders.contains(ObjectIdentifier(originalProvider)) {
+                let anyProvider = AnyProvider(originalProvider)
+                cyclicDependencyHandler("\nRe-entrant cyclic dependency detected. \(anyProvider) tried to resolve itself via a direct pod reference.")
+            }
             return makeInternalResolver().resolve(originalProvider)
         }
         return dispatchQueue.sync {
@@ -65,7 +75,9 @@ public final class SwiftiePod: ProviderResolver, @unchecked Sendable {
         InternalProviderResolver(
             instanceContainer: instanceContainer,
             processingAnyProviders: ProcessingAnyProviders.getInitial(),
-            providerOverrider: providerOverrider
+            providerOverrider: providerOverrider,
+            onBuildStart: { [self] id in currentlyBuildingProviders.insert(id) },
+            onBuildEnd: { [self] id in currentlyBuildingProviders.remove(id) }
         )
     }
 

--- a/SwiftiePod.podspec
+++ b/SwiftiePod.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'SwiftiePod'
-    s.version      = '1.1.2'
+    s.version      = '1.1.3'
     s.summary      = 'A Dependency Injection library for Swift'
     s.description  = 'SwiftiePod is a lightweight and easy-to-use Dependency Injection (DI) library for Swift. It is designed to be straightforward, efficient, and most importantly safe!'
     s.homepage     = 'https://github.com/robert-northmind/SwiftiePod'

--- a/Tests/SwiftiePodTests/ReentrantResolveTests.swift
+++ b/Tests/SwiftiePodTests/ReentrantResolveTests.swift
@@ -121,6 +121,47 @@ struct ReentrantResolveTests {
     }
 }
 
+    // MARK: - Self-referential re-entrant cycle (issue #5)
+
+    /// A provider whose builder calls `pod.resolve()` on **itself** (via a
+    /// direct pod reference) must be detected as a cyclic dependency and call
+    /// `cyclicDependencyHandler` rather than looping forever.
+    ///
+    /// Uses the same thread-blocking pattern as the existing cyclic dependency
+    /// test to prevent the resolve thread from continuing after the handler fires.
+    @Test("Re-entrant self-cycle via direct pod reference calls cyclic dependency handler (issue #5)")
+    func testReentrantSelfCycleIsDetected() {
+        let pod = SwiftiePod()
+
+        let detectedCycle = ThreadSafeResults<String>()
+        let detected = DispatchSemaphore(value: 0)
+
+        let originalHandler = cyclicDependencyHandler
+        cyclicDependencyHandler = { message in
+            detectedCycle.append(message)
+            detected.signal()
+            // Block the thread so execution does not fall through after detection.
+            repeat { Thread.sleep(forTimeInterval: 86400) } while true
+        }
+
+        // The provider captures itself and calls pod.resolve() on itself directly.
+        var selfRefProvider: Provider<String>?
+        selfRefProvider = Provider<String> { _ in
+            pod.resolve(selfRefProvider!)  // ← re-entrant self-cycle
+        }
+
+        let resolveThread = Thread {
+            _ = pod.resolve(selfRefProvider!)
+        }
+        resolveThread.start()
+
+        detected.wait()
+        cyclicDependencyHandler = originalHandler
+
+        #expect(detectedCycle.values.count == 1)
+        #expect(detectedCycle.values.first?.contains("Re-entrant cyclic dependency detected") == true)
+    }
+
 // MARK: - Test helpers
 
 private final class LoggerStub {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #5.

- **Self-cycle detection**: a provider whose builder calls `pod.resolve()` on itself via a direct pod reference is now detected as a cyclic dependency and reported via `cyclicDependencyHandler`, instead of causing infinite recursion and a stack overflow.
- **How**: `InternalProviderResolver` now accepts optional `onBuildStart`/`onBuildEnd` callbacks that fire around every `provider.build(...)` call. `SwiftiePod` maintains a `Set<ObjectIdentifier>` (`currentlyBuildingProviders`) via these callbacks, and checks it in the re-entrant fast-path before proceeding.
- **Version bump**: `1.1.2` → `1.1.3` (podspec + CHANGELOG).

## Performance impact

Negligible — the callbacks only fire on cache misses. Singleton providers pay the cost once ever; `AlwaysCreateNewScope` providers pay two closure calls + two O(1) Set operations per resolve, which is dwarfed by the builder execution and `dispatchQueue.sync` overhead.

## Test plan

- [ ] `testReentrantSelfCycleIsDetected` — new test in `ReentrantResolveTests`: verifies that a self-referential re-entrant provider triggers `cyclicDependencyHandler` with the expected message
- [ ] All existing tests continue to pass (callbacks default to `nil`, so no existing behaviour changes)
- [ ] CI: `swift test`, ExampleApp build, iOS simulator build + tests
EOF
)