### PR TITLE
Fix cyclic dependency test race

### DIFF
--- a/Tests/SwiftiePodTests/ReentrantResolveTests.swift
+++ b/Tests/SwiftiePodTests/ReentrantResolveTests.swift
@@ -68,7 +68,7 @@ struct ReentrantResolveTests {
         let semaphore = DispatchSemaphore(value: 0)
         var resolvedValue: String?
 
-        DispatchQueue.global().async {
+        DispatchQueue.global(qos: .userInitiated).async {
             resolvedValue = pod.resolve(outerProvider)
             semaphore.signal()
         }
@@ -106,7 +106,7 @@ struct ReentrantResolveTests {
         let semaphore = DispatchSemaphore(value: 0)
         var service: ServiceStub?
 
-        DispatchQueue.global().async {
+        DispatchQueue.global(qos: .userInitiated).async {
             service = pod.resolve(serviceProvider)
             semaphore.signal()
         }
@@ -131,35 +131,37 @@ struct ReentrantResolveTests {
     /// test to prevent the resolve thread from continuing after the handler fires.
     @Test("Re-entrant self-cycle via direct pod reference calls cyclic dependency handler (issue #5)")
     func testReentrantSelfCycleIsDetected() {
-        let pod = SwiftiePod()
+        withExclusiveCyclicDependencyHandler {
+            let pod = SwiftiePod()
 
-        let detectedCycle = ThreadSafeResults<String>()
-        let detected = DispatchSemaphore(value: 0)
+            let detectedCycle = ThreadSafeResults<String>()
+            let detected = DispatchSemaphore(value: 0)
 
-        let originalHandler = cyclicDependencyHandler
-        cyclicDependencyHandler = { message in
-            detectedCycle.append(message)
-            detected.signal()
-            // Block the thread so execution does not fall through after detection.
-            repeat { Thread.sleep(forTimeInterval: 86400) } while true
+            let originalHandler = cyclicDependencyHandler
+            defer { cyclicDependencyHandler = originalHandler }
+            cyclicDependencyHandler = { message in
+                detectedCycle.append(message)
+                detected.signal()
+                // Block the thread so execution does not fall through after detection.
+                repeat { Thread.sleep(forTimeInterval: 86400) } while true
+            }
+
+            // The provider captures itself and calls pod.resolve() on itself directly.
+            var selfRefProvider: Provider<String>?
+            selfRefProvider = Provider<String> { _ in
+                pod.resolve(selfRefProvider!)  // ← re-entrant self-cycle
+            }
+
+            let queue = DispatchQueue(label: "reentrant-self-cycle-test", qos: .userInitiated)
+            queue.async {
+                _ = pod.resolve(selfRefProvider!)
+            }
+
+            detected.wait()
+
+            #expect(detectedCycle.values.count == 1)
+            #expect(detectedCycle.values.first?.contains("Re-entrant cyclic dependency detected") == true)
         }
-
-        // The provider captures itself and calls pod.resolve() on itself directly.
-        var selfRefProvider: Provider<String>?
-        selfRefProvider = Provider<String> { _ in
-            pod.resolve(selfRefProvider!)  // ← re-entrant self-cycle
-        }
-
-        let resolveThread = Thread {
-            _ = pod.resolve(selfRefProvider!)
-        }
-        resolveThread.start()
-
-        detected.wait()
-        cyclicDependencyHandler = originalHandler
-
-        #expect(detectedCycle.values.count == 1)
-        #expect(detectedCycle.values.first?.contains("Re-entrant cyclic dependency detected") == true)
     }
 
 // MARK: - Test helpers

--- a/Tests/SwiftiePodTests/SwiftiePodTests.swift
+++ b/Tests/SwiftiePodTests/SwiftiePodTests.swift
@@ -290,31 +290,32 @@ struct SwiftiePodTests {
 
     @Test("Cyclic dependency is detected")
     func testCyclicProviders() {
-        let capturedMessage = ThreadSafeResults<String>()
-        let detected = DispatchSemaphore(value: 0)
+        withExclusiveCyclicDependencyHandler {
+            let capturedMessage = ThreadSafeResults<String>()
+            let detected = DispatchSemaphore(value: 0)
 
-        let originalHandler = cyclicDependencyHandler
-        cyclicDependencyHandler = { message in
-            capturedMessage.append(message)
-            detected.signal()
-            // Block the thread forever instead of exiting it.
-            // Thread.exit() would leave the SwiftiePod dispatch queue
-            // in a bad state and crash the process.
-            repeat { Thread.sleep(forTimeInterval: 86400) } while true
+            let originalHandler = cyclicDependencyHandler
+            defer { cyclicDependencyHandler = originalHandler }
+            cyclicDependencyHandler = { message in
+                capturedMessage.append(message)
+                detected.signal()
+                // Block the thread forever instead of exiting it.
+                // Thread.exit() would leave the SwiftiePod dispatch queue
+                // in a bad state and crash the process.
+                repeat { Thread.sleep(forTimeInterval: 86400) } while true
+            }
+
+            let queue = DispatchQueue(label: "cyclic-dependency-test", qos: .userInitiated)
+            queue.async {
+                let testPod = SwiftiePod()
+                _ = testPod.resolve(cyclicProvider)
+            }
+
+            detected.wait()
+
+            #expect(capturedMessage.values.count == 1)
+            #expect(capturedMessage.values.first?.contains("Dependencies cycle detected") == true)
         }
-
-        let thread = Thread {
-            let testPod = SwiftiePod()
-            _ = testPod.resolve(cyclicProvider)
-        }
-        thread.start()
-
-        detected.wait()
-
-        cyclicDependencyHandler = originalHandler
-
-        #expect(capturedMessage.values.count == 1)
-        #expect(capturedMessage.values.first?.contains("Dependencies cycle detected") == true)
     }
 
     // MARK: - Dependency chain tests

--- a/Tests/SwiftiePodTests/TestUtils.swift
+++ b/Tests/SwiftiePodTests/TestUtils.swift
@@ -116,6 +116,15 @@ final class ThreadSafeResults<T>: @unchecked Sendable {
     }
 }
 
+private let cyclicDependencyHandlerTestLock = NSLock()
+
+@discardableResult
+func withExclusiveCyclicDependencyHandler<T>(_ body: () -> T) -> T {
+    cyclicDependencyHandlerTestLock.lock()
+    defer { cyclicDependencyHandlerTestLock.unlock() }
+    return body()
+}
+
 struct MockProviderResolver: ProviderResolver {
     func resolve<T>(_ provider: Provider<T>) -> T {
         return provider.build(self)


### PR DESCRIPTION
## What changed

This fixes a race introduced in the recent re-entrant resolve test coverage.

The new issue #5 test in `ReentrantResolveTests.swift` overrides the shared global `cyclicDependencyHandler`, but the existing cyclic dependency test in `SwiftiePodTests.swift` does the same. Because Swift Testing runs tests in parallel, those two tests could interfere with each other and assert against the wrong handler output.

This PR makes the test setup exclusive when replacing `cyclicDependencyHandler`, and also aligns the re-entrant test worker queues with user-initiated QoS.

## Why

The regression was reproducible in the test suite itself:

- `xcodebuild test -scheme SwiftiePod -destination 'platform=macOS'`

Before this fix, the two cyclic-dependency tests could fail nondeterministically because they were mutating shared global state at the same time.

## Root cause

Both tests relied on swapping a process-global handler:

- `Tests/SwiftiePodTests/SwiftiePodTests.swift`
- `Tests/SwiftiePodTests/ReentrantResolveTests.swift`

That was safe while run in isolation, but not once both tests were eligible to execute concurrently.

## Implementation

- Added a small test-only lock helper in `Tests/SwiftiePodTests/TestUtils.swift`
- Wrapped both handler-mutating tests in that exclusive section
- Switched the re-entrant test background work to user-initiated queues

## Impact

This change is test-only. It does not modify library/runtime behavior in `Sources/`.

It removes a flaky test interaction and keeps the newer re-entrant cycle coverage in place.

## Validation

- `xcodebuild test -scheme SwiftiePod -destination 'platform=macOS'`
