### PR TITLE
[codex] Harden repository security configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,16 @@
 /.build
 /Packages
 xcuserdata/
+*.xcuserstate
 DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.claude/
+.cursor/
+.env
+.env.*
+!.env.example
+.npmrc
+.pypirc
+.yarnrc.yml
 .netrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Dependabot configuration for GitHub Actions updates.
+
+### Changed
+
+- Expanded ignored local configuration and secret-related files.
+- Internal provider resolver callbacks are now marked `@Sendable` to satisfy stricter Swift concurrency checks.
+
 ## [1.1.3] - 2026-03-31
 
 ### Fixed
@@ -70,3 +81,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.8...1.1.0
 [1.0.8]: https://github.com/robert-northmind/SwiftiePod/compare/1.0.0...1.0.8
 [1.0.0]: https://github.com/robert-northmind/SwiftiePod/releases/tag/1.0.0
+[Unreleased]: https://github.com/robert-northmind/SwiftiePod/compare/1.1.3...HEAD

--- a/Sources/SwiftiePod/InternalProviderResolver.swift
+++ b/Sources/SwiftiePod/InternalProviderResolver.swift
@@ -12,8 +12,8 @@ struct InternalProviderResolver: ProviderResolver {
         instanceContainer: ProviderInstanceContainer,
         processingAnyProviders: ProcessingAnyProviders,
         providerOverrider: ProviderOverrider,
-        onBuildStart: ((ObjectIdentifier) -> Void)? = nil,
-        onBuildEnd: ((ObjectIdentifier) -> Void)? = nil
+        onBuildStart: (@Sendable (ObjectIdentifier) -> Void)? = nil,
+        onBuildEnd: (@Sendable (ObjectIdentifier) -> Void)? = nil
     ) {
         self.instanceContainer = instanceContainer
         self.processingAnyProviders = processingAnyProviders
@@ -25,8 +25,8 @@ struct InternalProviderResolver: ProviderResolver {
     private let instanceContainer: ProviderInstanceContainer
     private let processingAnyProviders: ProcessingAnyProviders
     private let providerOverrider: ProviderOverrider
-    private let onBuildStart: ((ObjectIdentifier) -> Void)?
-    private let onBuildEnd: ((ObjectIdentifier) -> Void)?
+    private let onBuildStart: (@Sendable (ObjectIdentifier) -> Void)?
+    private let onBuildEnd: (@Sendable (ObjectIdentifier) -> Void)?
 
     func resolve<T>(_ originalProvider: Provider<T>) -> T {
         let anyProvider = AnyProvider(originalProvider)


### PR DESCRIPTION
## Summary

- Add Dependabot updates for GitHub Actions
- Expand local secret/editor config ignores
- Mark internal resolver callbacks as `@Sendable` for stricter Swift concurrency checks
- Document the hardening changes in the changelog

## Verification

- [x] `swift test`
- [x] `zizmor .github/workflows/ci.yml`
- [x] `.github/dependabot.yml` parses as YAML
